### PR TITLE
Pequenas contribuições

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # máquina nodejs
-FROM node:latest
+FROM node:11
 
 # criando diretório onde o app ficará armazenado na máquina
 RUN mkdir -p /usr/src/apiasep

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # apiasep
 API para consulta de cotas de exames do IASEP. Basicamente um webcrawler. Powered by NodeJS.
 
-# instalando dependências
-yarn ou npm install
+## Rodando sem Docker
+### Instale as dependências
+`yarn install` ou `npm install`
 
-# rodando
-yarn start ou npm start
+### Inicie o servidor
+`yarn start` ou `npm start`
 
-# documentação
-localhost:3000/api-docs
+## Rodando com Docker
+### Construa a imagem
+```
+docker build -t apiasep:1.0.0 .
+```
+
+### Inicie um container
+```
+docker run -it --rm -p 3000:3000 apiasep
+```
+
+# Documentação
+Após iniciar o servidor, a documentação estará disponível em http://localhost:3000/api-docs

--- a/helpers/cotaHelper.js
+++ b/helpers/cotaHelper.js
@@ -46,9 +46,7 @@ let getCookie = async (cpf, adesao) => {
 };
 
 let getCota = async (cookie) => {
-    //  spread operators não funcionando no docker   
-    //     let uri = { ... uri_padrao };
-    let uri = Object.assign({}, uri_padrao);
+    let uri = { ... uri_padrao };
     uri.form = {
         'do': 'PortalSegurado.extrato'
     };


### PR DESCRIPTION
Adicionei mais alguns detalhes no README.md e também alterei a tag da imagem do nodejs no Dockerfile. Usando a tag 11, terá certeza de que usará a versão que suporta `spread operator`. Por isso desfiz a última alteração que retirava esse operador.